### PR TITLE
Show error when passwordConfirm is empty

### DIFF
--- a/passwordconfirm/PasswordConfirmPlugin.php
+++ b/passwordconfirm/PasswordConfirmPlugin.php
@@ -49,7 +49,7 @@ class PasswordConfirmPlugin extends BasePlugin
             {
                 $password = craft()->request->getPost('password');
                 $passwordConfirm = craft()->request->getPost('passwordConfirm');
-                if($passwordConfirm && strcmp($password, $passwordConfirm) !== 0)
+                if(isset($passwordConfirm) && strcmp($password, $passwordConfirm) !== 0)
                 {
                     $event->params['user']->addErrors(array('passwordConfirm' => Craft::t('Passwords do not match')));
                     $event->performAction = false;


### PR DESCRIPTION
Fixes the issue @OliverMaerz mentioned in #2:

> If the user only fills out password field (and leaves passwordConfirm empty) then no error is displayed and user is registered.